### PR TITLE
Changing dependency from :java (which is disabled) to openjdk

### DIFF
--- a/fastrtps.rb
+++ b/fastrtps.rb
@@ -9,7 +9,7 @@ class Fastrtps < Formula
 
   depends_on "cmake" => :build
   depends_on "gradle" => :build
-  depends_on :java
+  depends_on "openjdk"
 
   bottle do
     root_url "http://px4-tools.s3.amazonaws.com"

--- a/px4-dev.rb
+++ b/px4-dev.rb
@@ -12,7 +12,7 @@ class Px4Dev < Formula
 	depends_on "ant"
 	depends_on "fastrtps"
 	depends_on "fastcdr"
-	depends_on :java
+	depends_on "openjdk"
 
 	homepage 'http://px4.io'
 	version '1.6.5.0'


### PR DESCRIPTION


When running `brew tap ardupilot/homebrew-px4` in Mac OS Big Sur got the following error

```
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/ardupilot/homebrew-px4/px4-dev.rb
px4-dev: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the ardupilot/px4 tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/ardupilot/homebrew-px4/px4-dev.rb:15

Warning: Calling depends_on :x11 is deprecated! Use depends_on specific X11 formula(e) instead.
Please report this issue to the ardupilot/px4 tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/ardupilot/homebrew-px4/px4-sim.rb:5

Error: Invalid formula: /usr/local/Homebrew/Library/Taps/ardupilot/homebrew-px4/fastrtps.rb
fastrtps: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the ardupilot/px4 tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/ardupilot/homebrew-px4/fastrtps.rb:12

Error: Cannot tap ardupilot/px4: invalid syntax in tap!
```

Fixed it by making the recommended changes i.e. changing `depends_on :java` to `depends:on "openjdk"`